### PR TITLE
Fixed cache location. Fixes #4

### DIFF
--- a/src/main/groovy/com/wynprice/cursemaven/repo/CurseMavenRepo.groovy
+++ b/src/main/groovy/com/wynprice/cursemaven/repo/CurseMavenRepo.groovy
@@ -32,7 +32,7 @@ import java.nio.file.Paths
      * @param project the project to initialize from
      */
     static void initialize(Project project) {
-        def path = Paths.get(project.gradle.gradleHomeDir.path, "caches")
+        def path = Paths.get(project.gradle.gradleUserHomeDir.path, "caches")
 
         //Setup the maven
         project.repositories.maven { MavenArtifactRepository repo ->


### PR DESCRIPTION
Fixes the cache location to use the `.gradle\caches` in the users home directory instead of `$GRADLE_HOME\caches`.